### PR TITLE
Fix typo: edif -> ediff

### DIFF
--- a/init.el
+++ b/init.el
@@ -523,7 +523,7 @@
 
 ;; ediff
 
-(use-package edif
+(use-package ediff
   :ensure nil
   :custom
   (ediff-keep-variants nil)


### PR DESCRIPTION
Because of the missing letter Emacs is unable to use the package “ediff”. I tested this change locally.

PS: Thank you for providing this repository and guide on your website :) 