### PR TITLE
Fix minor typos in chapter 07 and 08

### DIFF
--- a/documents/book/07-production.org
+++ b/documents/book/07-production.org
@@ -27,7 +27,7 @@
 
 Chapter [[#chap-vanilla]] laid the groundwork for writing plain text documents, and chapter [[#chap-ews]] introduced the basics of Org syntax. This chapter builds on these foundations and guides you through preparing a manuscript for publication using the unique features of Org mode and some additional tools to facilitate your writing process.
 
-This chapter shows how to add editorial notes, citations and cross-references. You can also use  text completion to accelerate the writing process. Writing without a dictionary or thesaurus To manage the quality of your writing you might like to use a dictionary and thesaurus to enhance the variety of prose. This chapter also explains how  to manage large writing projects and control versions and collaborate with other authors.
+This chapter shows how to add editorial notes, citations and cross-references. You can also use  text completion to accelerate the writing process. Writing without a dictionary or thesaurus to manage the quality of your writing you might like to use a dictionary and thesaurus to enhance the variety of prose. This chapter also explains how  to manage large writing projects and control versions and collaborate with other authors.
 
 The last section of this chapter introduces other text modes that might interest authors, such as Markdown for technical documentation and the specialised Fountain mode for film and theatre scripts.
 

--- a/documents/book/07-production.org
+++ b/documents/book/07-production.org
@@ -452,7 +452,7 @@ The mode bar of your file will now show an indicator that it is under version co
 #+RESULTS:
 [[file:images/version-control.png]]
 
-You can produce a list of current file changes with =C-x v l= or ~vc-print-log~. This list shows the unique commit ID, the author, the change date, and a summary of the changes, with the most recent version at the top. Navigate between the various versions with =n= (next) and =p= (previous). You can view the changes between versions with the =d= key. Selecting more than one commit with the =m= and arrow keys and then =d= shows the differences between the oldest and latest versions. To quit this view, use the trusty =q== key. To view changes in the whole repository, use =C-x v L= (~vc-print-root-log~).
+You can produce a list of current file changes with =C-x v l= or ~vc-print-log~. This list shows the unique commit ID, the author, the change date, and a summary of the changes, with the most recent version at the top. Navigate between the various versions with =n= (next) and =p= (previous). You can view the changes between versions with the =d= key. Selecting more than one commit with the =m= and arrow keys and then =d= shows the differences between the oldest and latest versions. To quit this view, use the trusty =q= key. To view changes in the whole repository, use =C-x v L= (~vc-print-root-log~).
 
 There is also a command to show the development history of a selected text region. Select the part of the text you are interested in and use =C-x v h= (~vc-region-history~). This buffer works the same way as the previous two examples. The ~vc-annotate~ command (=C-x v g=) shows the relevant commit for each line in the text, coloured by the age of the contribution.
 

--- a/documents/book/08-publication.org
+++ b/documents/book/08-publication.org
@@ -312,7 +312,7 @@ Controlling typography and layout for office documents requires an OpenDocument 
 
 Creating a style file template is straightforward. Create an empty Org document, add =#+options: H:4 num:t author:nil= and export to ODT with =C-c C-e o o=. The options keyword creates four numbered heading levels. You can obviously modify these settings to suite your preference. Open the exported document with LibreOffice and edit the styles (=F11=).  
 
-Org mode uses some particular styles that start with "Org", so ensure you configure these. When the document is styled to your liking, save it as an OTT file and attach it to your manuscript. The next time you export the Org document, the output will be in the style defined in the template. Org extracts the =styles.xml= file embedded in your template file and copies it t the exported file.
+Org mode uses some particular styles that start with "Org", so ensure you configure these. When the document is styled to your liking, save it as an OTT file and attach it to your manuscript. The next time you export the Org document, the output will be in the style defined in the template. Org extracts the =styles.xml= file embedded in your template file and copies it to the exported file.
 
 When your styles contain images, for example a background image for a page, you need to also specify this in the styles file keyword as in the example below. The =styles.xml= has to be specified and the =background.png= file is the one nominated as a background image in the template document. Note that LibreOffice renames files so you need to open the template with Emacs and press =C-C C-c= to see the structure of the file and copy the image file name. This setup is ideal for writing corporate documents.
 


### PR DESCRIPTION
Hi,

First of great book, I finished it a few weeks ago, I got some great suggestions on how I could improve my technical writing and note taking. Thank you for taking the time writing it.

I did find some minor typos when reading so here are the fixes for them.

There was also this sentence in the third paragraph of section 10.5:

> Some cynics suggest that those who can't teach.

It seems to be cut off, or should it be " Some cynics suggest that those can't teach."?

Here is the full paragraph:

> The EWS project is my way of giving back to the Emacs community and also helping me better understand how the software works. Some cynics suggest that those who can't teach. However, teaching any subject is the best way to systematise your knowledge and become better at it.

I did not change anything for that as it could just be me not reading it correctly.