### PR TITLE
Fix denote-org "extract-subtree" function name.

### DIFF
--- a/documents/book/99-appendix.org
+++ b/documents/book/99-appendix.org
@@ -703,7 +703,7 @@ The Denote-Org package by Prot enhances functionality when working with Org file
     (use-package denote-org
       :bind
       (("C-c w d h" . denote-org-link-to-heading)
-       ("C-c w d s" . denote-org-extract-subtree)))
+       ("C-c w d s" . denote-org-extract-org-subtree)))
 #+end_src
 
 ** Bibliographic Notes

--- a/init.el
+++ b/init.el
@@ -424,7 +424,7 @@
 (use-package denote-org
   :bind
   (("C-c w d h" . denote-org-link-to-heading)
-   ("C-c w d s" . denote-org-extract-subtree)))
+   ("C-c w d s" . denote-org-extract-org-subtree)))
 
 ;; Consult convenience functions
 


### PR DESCRIPTION
The actual function name appears to be denote-org-extract-org-subtree.